### PR TITLE
fix: switch from fasthash to murmur3 and expose internal functions

### DIFF
--- a/optimizely/Cargo.toml
+++ b/optimizely/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 serde_json = "1.0.107"
 thiserror = "1.0"
 error-stack = "0.3.1"
-fasthash = "0.4.0"
+murmur3 = "0.5.2"
 log = "0.4.17"
 
 [dependencies.serde]

--- a/optimizely/src/client/user.rs
+++ b/optimizely/src/client/user.rs
@@ -1,6 +1,7 @@
 // External imports
-use fasthash::murmur3::hash32_with_seed as murmur3_hash;
+use murmur3::murmur3_32 as murmur3_hash;
 use std::collections::HashMap;
+use std::io::Cursor;
 
 // Imports from crate
 use crate::datafile::{Experiment, FeatureFlag, Variation};
@@ -185,7 +186,7 @@ impl UserContext<'_> {
 
         // To hash the bucket key it needs to be converted to an array of `u8` bytes
         // Use Murmur3 (32-bit) with seed
-        let hash_value = murmur3_hash(bucketing_key.as_bytes(), HASH_SEED);
+        let hash_value = murmur3_hash(&mut Cursor::new(bucketing_key), HASH_SEED).unwrap();
 
         // Bring the hash into a range of 0 to 10_000
         let bucket_value = ((hash_value as f64) / (u32::MAX as f64) * MAX_OF_RANGE) as u64;

--- a/optimizely/src/client/user.rs
+++ b/optimizely/src/client/user.rs
@@ -174,7 +174,7 @@ impl UserContext<'_> {
         }
     }
 
-    fn decide_variation_for_experiment<'a>(
+    pub fn decide_variation_for_experiment<'a>(
         &'a self, experiment: &'a Experiment, send_decision: bool,
     ) -> Option<&Variation> {
         // Use references for the ids

--- a/optimizely/src/client/user.rs
+++ b/optimizely/src/client/user.rs
@@ -186,7 +186,13 @@ impl UserContext<'_> {
 
         // To hash the bucket key it needs to be converted to an array of `u8` bytes
         // Use Murmur3 (32-bit) with seed
-        let hash_value = murmur3_hash(&mut Cursor::new(bucketing_key), HASH_SEED).unwrap();
+        let hash_value = match murmur3_hash(&mut Cursor::new(&bucketing_key), HASH_SEED) {
+            Ok(value) => value,
+            Err(_e) => {
+                log::warn!("Unable to create hash for bucketing_key={}", &bucketing_key);
+                return None;
+            }
+        };
 
         // Bring the hash into a range of 0 to 10_000
         let bucket_value = ((hash_value as f64) / (u32::MAX as f64) * MAX_OF_RANGE) as u64;

--- a/optimizely/src/datafile.rs
+++ b/optimizely/src/datafile.rs
@@ -1,5 +1,6 @@
 //! Parsing the Optimizely datafile
 
+use std::collections::HashMap;
 // External imports
 use error_stack::{IntoReport, Result, ResultExt};
 
@@ -59,6 +60,11 @@ impl Datafile {
     /// Get the flag with the given key
     pub fn flag(&self, flag_key: &str) -> Option<&FeatureFlag> {
         self.0.feature_flags().get(flag_key)
+    }
+
+    /// Get all experiments
+    pub fn experiments(&self) -> &HashMap<String, Experiment> {
+        self.0.experiments()
     }
 
     /// Get the experiment with the given experiment ID

--- a/optimizely/src/datafile.rs
+++ b/optimizely/src/datafile.rs
@@ -21,7 +21,7 @@ mod experiment;
 mod feature_flag;
 mod rollout;
 mod traffic_allocation;
-mod variation;
+pub mod variation;
 
 /// The datafile contains all the feature flags, experiments, events and other configuration from an Optimizely account.
 ///

--- a/optimizely/src/datafile/experiment.rs
+++ b/optimizely/src/datafile/experiment.rs
@@ -9,6 +9,8 @@ use super::{TrafficAllocation, Variation};
 pub struct Experiment {
     #[serde()]
     id: String,
+    #[serde()]
+    key: String,
     #[serde(rename = "layerId")]
     campaign_id: String,
     #[serde(rename = "trafficAllocation", deserialize_with = "TrafficAllocation::deserialize")]
@@ -33,6 +35,11 @@ impl Experiment {
     #[allow(dead_code)]
     pub fn id(&self) -> &str {
         &self.id
+    }
+
+    #[allow(dead_code)]
+    pub fn key(&self) -> &str {
+        &self.key
     }
 
     #[allow(dead_code)]

--- a/optimizely/src/datafile/variation.rs
+++ b/optimizely/src/datafile/variation.rs
@@ -15,8 +15,12 @@ pub struct Variation {
     id: String,
     #[serde()]
     key: String,
-    #[serde(rename = "featureEnabled")]
+    #[serde(rename = "featureEnabled", default = "default_as_true")]
     is_feature_enabled: bool,
+}
+
+fn default_as_true() -> bool {
+    true
 }
 
 impl Variation {


### PR DESCRIPTION
These are changes needed to be able to use this SDK in our rust fastly C@E.

The main change was to switch our the library that provides the murmur3 hash since the existing one was not compilable in the fastly/wasm runtime. The other changes are to just expose additional data that we need and to have experiment variations enabled by default (our datafile was missing the key in some cases for enabled variations).