### PR TITLE
feat: evaluating audience conditions, ZUM-62846

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: cimg/rust:1.76.0
+    steps:
+      - checkout
+      - run: cargo --version
+      - run:
+          name: Run Tests
+          command: "cargo test"

--- a/datafiles/sandbox.json
+++ b/datafiles/sandbox.json
@@ -1,610 +1,697 @@
 {
-    "groups": [],
-    "environmentKey": "development",
-    "rollouts": [
-      {
-        "experiments": [
-          {
-            "status": "Running",
-            "audienceConditions": [],
-            "audienceIds": [],
-            "variations": [
-              {
-                "variables": [],
-                "id": "58054",
-                "key": "on",
-                "featureEnabled": true
-              }
-            ],
-            "forcedVariations": {},
-            "key": "qa_rollout_targeted_delivery",
-            "layerId": "9300000098307",
-            "trafficAllocation": [
-              {
-                "entityId": "58054",
-                "endOfRange": 5000
-              }
-            ],
-            "id": "9300000131788"
-          },
-          {
-            "status": "Running",
-            "audienceConditions": [],
-            "audienceIds": [],
-            "variations": [
-              {
-                "variables": [],
-                "id": "58053",
-                "key": "off",
-                "featureEnabled": false
-              }
-            ],
-            "forcedVariations": {},
-            "key": "default-rollout-19334-21533480907",
-            "layerId": "rollout-19334-21533480907",
-            "trafficAllocation": [
-              {
-                "entityId": "58053",
-                "endOfRange": 10000
-              }
-            ],
-            "id": "default-rollout-19334-21533480907"
-          }
+  "groups": [],
+  "environmentKey": "development",
+  "rollouts": [
+    {
+      "experiments": [
+        {
+          "status": "Running",
+          "audienceConditions": [],
+          "audienceIds": [],
+          "variations": [
+            {
+              "variables": [],
+              "id": "58054",
+              "key": "on",
+              "featureEnabled": true
+            }
+          ],
+          "forcedVariations": {},
+          "key": "qa_rollout_targeted_delivery",
+          "layerId": "9300000098307",
+          "trafficAllocation": [
+            {
+              "entityId": "58054",
+              "endOfRange": 5000
+            }
+          ],
+          "id": "9300000131788"
+        },
+        {
+          "status": "Running",
+          "audienceConditions": [],
+          "audienceIds": [],
+          "variations": [
+            {
+              "variables": [],
+              "id": "58053",
+              "key": "off",
+              "featureEnabled": false
+            }
+          ],
+          "forcedVariations": {},
+          "key": "default-rollout-19334-21533480907",
+          "layerId": "rollout-19334-21533480907",
+          "trafficAllocation": [
+            {
+              "entityId": "58053",
+              "endOfRange": 10000
+            }
+          ],
+          "id": "default-rollout-19334-21533480907"
+        }
+      ],
+      "id": "rollout-19334-21533480907"
+    },
+    {
+      "experiments": [
+        {
+          "status": "Running",
+          "audienceConditions": [],
+          "audienceIds": [],
+          "variations": [
+            {
+              "variables": [],
+              "id": "87755",
+              "key": "primary",
+              "featureEnabled": true
+            }
+          ],
+          "forcedVariations": {},
+          "key": "default-rollout-29807-21533480907",
+          "layerId": "rollout-29807-21533480907",
+          "trafficAllocation": [
+            {
+              "entityId": "87755",
+              "endOfRange": 10000
+            }
+          ],
+          "id": "default-rollout-29807-21533480907"
+        }
+      ],
+      "id": "rollout-29807-21533480907"
+    },
+    {
+      "experiments": [
+        {
+          "status": "Running",
+          "audienceConditions": [],
+          "audienceIds": [],
+          "variations": [
+            {
+              "variables": [
+                {
+                  "id": "13752",
+                  "value": "/index.html"
+                }
+              ],
+              "id": "84129",
+              "key": "off",
+              "featureEnabled": false
+            }
+          ],
+          "forcedVariations": {},
+          "key": "default-rollout-28662-21533480907",
+          "layerId": "rollout-28662-21533480907",
+          "trafficAllocation": [
+            {
+              "entityId": "84129",
+              "endOfRange": 10000
+            }
+          ],
+          "id": "default-rollout-28662-21533480907"
+        }
+      ],
+      "id": "rollout-28662-21533480907"
+    },
+    {
+      "experiments": [
+        {
+          "status": "Running",
+          "audienceConditions": [],
+          "audienceIds": [],
+          "variations": [
+            {
+              "variables": [
+                {
+                  "id": "8291",
+                  "value": "desc"
+                },
+                {
+                  "id": "8290",
+                  "value": "price"
+                },
+                {
+                  "id": "8289",
+                  "value": "4"
+                }
+              ],
+              "id": "44477",
+              "key": "variation_1",
+              "featureEnabled": true
+            }
+          ],
+          "forcedVariations": {},
+          "key": "default-rollout-15415-21533480907",
+          "layerId": "rollout-15415-21533480907",
+          "trafficAllocation": [
+            {
+              "entityId": "44477",
+              "endOfRange": 10000
+            }
+          ],
+          "id": "default-rollout-15415-21533480907"
+        }
+      ],
+      "id": "rollout-15415-21533480907"
+    },
+    {
+      "experiments": [
+        {
+          "status": "Running",
+          "audienceConditions": [],
+          "audienceIds": [],
+          "variations": [
+            {
+              "variables": [
+                {
+                  "id": "10748",
+                  "value": "This is the title"
+                }
+              ],
+              "id": "58158",
+              "key": "off",
+              "featureEnabled": false
+            }
+          ],
+          "forcedVariations": {},
+          "key": "default-rollout-19359-21533480907",
+          "layerId": "rollout-19359-21533480907",
+          "trafficAllocation": [
+            {
+              "entityId": "58158",
+              "endOfRange": 10000
+            }
+          ],
+          "id": "default-rollout-19359-21533480907"
+        }
+      ],
+      "id": "rollout-19359-21533480907"
+    },
+    {
+      "experiments": [
+        {
+          "status": "Running",
+          "audienceConditions": [],
+          "audienceIds": [],
+          "variations": [
+            {
+              "variables": [],
+              "id": "58051",
+              "key": "off",
+              "featureEnabled": false
+            }
+          ],
+          "forcedVariations": {},
+          "key": "default-rollout-19333-21533480907",
+          "layerId": "rollout-19333-21533480907",
+          "trafficAllocation": [
+            {
+              "entityId": "58051",
+              "endOfRange": 10000
+            }
+          ],
+          "id": "default-rollout-19333-21533480907"
+        }
+      ],
+      "id": "rollout-19333-21533480907"
+    }
+  ],
+  "typedAudiences": [
+    {
+      "name": "[Web] Desktop + Mobile Web",
+      "conditions": [
+        "and",
+        [
+          "or",
+          [
+            "or",
+            {
+              "match": "substring",
+              "name": "platform",
+              "type": "custom_attribute",
+              "value": "web"
+            }
+          ]
         ],
-        "id": "rollout-19334-21533480907"
-      },
-      {
-        "experiments": [
-          {
-            "status": "Running",
-            "audienceConditions": [],
-            "audienceIds": [],
-            "variations": [
-              {
-                "variables": [],
-                "id": "87755",
-                "key": "primary",
-                "featureEnabled": true
-              }
-            ],
-            "forcedVariations": {},
-            "key": "default-rollout-29807-21533480907",
-            "layerId": "rollout-29807-21533480907",
-            "trafficAllocation": [
-              {
-                "entityId": "87755",
-                "endOfRange": 10000
-              }
-            ],
-            "id": "default-rollout-29807-21533480907"
-          }
+        [
+          "or",
+          [
+            "or",
+            {
+              "match": "exists",
+              "name": "isMobile",
+              "type": "custom_attribute",
+              "value": null
+            }
+          ]
+        ]
+      ],
+      "id": "18423300742"
+    },
+    {
+      "name": "optimizely",
+      "id": "18396710504",
+      "conditions": [
+        "and",
+        [
+          "or",
+          [
+            "or",
+            {
+              "match": "exists",
+              "name": "platform",
+              "type": "custom_attribute",
+              "value": null
+            }
+          ]
+        ]
+      ]
+    },
+    {
+      "name": "[Web] Desktop Only",
+      "id": "13858570732",
+      "conditions": [
+        "and",
+        [
+          "or",
+          [
+            "or",
+            {
+              "match": "exact",
+              "name": "isMobile",
+              "type": "custom_attribute",
+              "value": false
+            }
+          ]
         ],
-        "id": "rollout-29807-21533480907"
-      },
-      {
-        "experiments": [
-          {
-            "status": "Running",
-            "audienceConditions": [],
-            "audienceIds": [],
-            "variations": [
-              {
-                "variables": [
-                  {
-                    "id": "13752",
-                    "value": "/index.html"
-                  }
-                ],
-                "id": "84129",
-                "key": "off",
-                "featureEnabled": false
-              }
-            ],
-            "forcedVariations": {},
-            "key": "default-rollout-28662-21533480907",
-            "layerId": "rollout-28662-21533480907",
-            "trafficAllocation": [
-              {
-                "entityId": "84129",
-                "endOfRange": 10000
-              }
-            ],
-            "id": "default-rollout-28662-21533480907"
-          }
-        ],
-        "id": "rollout-28662-21533480907"
-      },
-      {
-        "experiments": [
-          {
-            "status": "Running",
-            "audienceConditions": [],
-            "audienceIds": [],
-            "variations": [
-              {
-                "variables": [
-                  {
-                    "id": "8291",
-                    "value": "desc"
-                  },
-                  {
-                    "id": "8290",
-                    "value": "price"
-                  },
-                  {
-                    "id": "8289",
-                    "value": "4"
-                  }
-                ],
-                "id": "44477",
-                "key": "variation_1",
-                "featureEnabled": true
-              }
-            ],
-            "forcedVariations": {},
-            "key": "default-rollout-15415-21533480907",
-            "layerId": "rollout-15415-21533480907",
-            "trafficAllocation": [
-              {
-                "entityId": "44477",
-                "endOfRange": 10000
-              }
-            ],
-            "id": "default-rollout-15415-21533480907"
-          }
-        ],
-        "id": "rollout-15415-21533480907"
-      },
-      {
-        "experiments": [
-          {
-            "status": "Running",
-            "audienceConditions": [],
-            "audienceIds": [],
-            "variations": [
-              {
-                "variables": [
-                  {
-                    "id": "10748",
-                    "value": "This is the title"
-                  }
-                ],
-                "id": "58158",
-                "key": "off",
-                "featureEnabled": false
-              }
-            ],
-            "forcedVariations": {},
-            "key": "default-rollout-19359-21533480907",
-            "layerId": "rollout-19359-21533480907",
-            "trafficAllocation": [
-              {
-                "entityId": "58158",
-                "endOfRange": 10000
-              }
-            ],
-            "id": "default-rollout-19359-21533480907"
-          }
-        ],
-        "id": "rollout-19359-21533480907"
-      },
-      {
-        "experiments": [
-          {
-            "status": "Running",
-            "audienceConditions": [],
-            "audienceIds": [],
-            "variations": [
-              {
-                "variables": [],
-                "id": "58051",
-                "key": "off",
-                "featureEnabled": false
-              }
-            ],
-            "forcedVariations": {},
-            "key": "default-rollout-19333-21533480907",
-            "layerId": "rollout-19333-21533480907",
-            "trafficAllocation": [
-              {
-                "entityId": "58051",
-                "endOfRange": 10000
-              }
-            ],
-            "id": "default-rollout-19333-21533480907"
-          }
-        ],
-        "id": "rollout-19333-21533480907"
-      }
-    ],
-    "typedAudiences": [],
-    "projectId": "21537940595",
-    "variables": [],
-    "featureFlags": [
-      {
-        "experimentIds": [],
-        "rolloutId": "rollout-19334-21533480907",
-        "variables": [],
-        "id": "19334",
-        "key": "qa_rollout"
-      },
-      {
-        "experimentIds": [
-          "9300000127039"
-        ],
-        "rolloutId": "rollout-29807-21533480907",
-        "variables": [],
-        "id": "29807",
-        "key": "buy_button"
-      },
-      {
-        "experimentIds": [
-          "9300000125242"
-        ],
-        "rolloutId": "rollout-28662-21533480907",
-        "variables": [
-          {
-            "defaultValue": "/index.html",
-            "type": "string",
-            "id": "13752",
-            "key": "path"
-          }
-        ],
-        "id": "28662",
-        "key": "hero_layout"
-      },
-      {
-        "experimentIds": [
-          "9300000061857"
-        ],
-        "rolloutId": "rollout-15415-21533480907",
-        "variables": [
-          {
-            "defaultValue": "asc",
-            "type": "string",
-            "id": "8291",
-            "key": "direction"
-          },
-          {
-            "defaultValue": "price",
-            "type": "string",
-            "id": "8290",
-            "key": "field"
-          },
-          {
-            "defaultValue": "3",
-            "type": "integer",
-            "id": "8289",
-            "key": "number_of_products"
-          }
-        ],
-        "id": "15415",
-        "key": "sorting_algorithm"
-      },
-      {
-        "experimentIds": [
-          "9300000090374"
-        ],
-        "rolloutId": "rollout-19359-21533480907",
-        "variables": [
-          {
-            "defaultValue": "This is the title",
-            "type": "string",
-            "id": "10748",
-            "key": "text"
-          }
-        ],
-        "id": "19359",
-        "key": "header_text"
-      },
-      {
-        "experimentIds": [],
-        "rolloutId": "rollout-19333-21533480907",
-        "variables": [],
-        "id": "19333",
-        "key": "simplified_checkout"
-      }
-    ],
-    "experiments": [
-      {
-        "status": "Running",
-        "audienceConditions": [],
-        "audienceIds": [],
-        "variations": [
-          {
-            "variables": [],
-            "id": "87756",
-            "key": "danger",
-            "featureEnabled": true
-          },
-          {
-            "variables": [],
-            "id": "87758",
-            "key": "warning",
-            "featureEnabled": true
-          },
-          {
-            "variables": [],
-            "id": "87757",
-            "key": "success",
-            "featureEnabled": true
-          },
-          {
-            "variables": [],
-            "id": "87755",
-            "key": "primary",
-            "featureEnabled": true
-          }
-        ],
-        "forcedVariations": {},
-        "key": "buy_button_experiment",
-        "layerId": "9300000093600",
-        "trafficAllocation": [
-          {
-            "entityId": "87755",
-            "endOfRange": 2500
-          },
-          {
-            "entityId": "87756",
-            "endOfRange": 5000
-          },
-          {
-            "entityId": "87757",
-            "endOfRange": 7500
-          },
-          {
-            "entityId": "87758",
-            "endOfRange": 10000
-          }
-        ],
-        "id": "9300000127039"
-      },
-      {
-        "status": "Running",
-        "audienceConditions": [],
-        "audienceIds": [],
-        "variations": [
-          {
-            "variables": [
-              {
-                "id": "13752",
-                "value": "/index.html"
-              }
-            ],
-            "id": "84133",
-            "key": "control",
-            "featureEnabled": true
-          },
-          {
-            "variables": [
-              {
-                "id": "13752",
-                "value": "/treatment.html"
-              }
-            ],
-            "id": "84134",
-            "key": "treatment",
-            "featureEnabled": true
-          }
-        ],
-        "forcedVariations": {},
-        "key": "hero_layout_experiment",
-        "layerId": "9300000091821",
-        "trafficAllocation": [
-          {
-            "entityId": "84133",
-            "endOfRange": 5000
-          },
-          {
-            "entityId": "84134",
-            "endOfRange": 10000
-          }
-        ],
-        "id": "9300000125242"
-      },
-      {
-        "status": "Running",
-        "audienceConditions": [],
-        "audienceIds": [],
-        "variations": [
-          {
-            "variables": [],
-            "id": "44475",
-            "key": "off",
-            "featureEnabled": false
-          },
-          {
-            "variables": [
-              {
-                "id": "8289",
-                "value": "4"
-              },
-              {
-                "id": "8291",
-                "value": "desc"
-              },
-              {
-                "id": "8290",
-                "value": "price"
-              }
-            ],
-            "id": "44477",
-            "key": "variation_1",
-            "featureEnabled": true
-          },
-          {
-            "variables": [
-              {
-                "id": "8289",
-                "value": "5"
-              },
-              {
-                "id": "8290",
-                "value": "category"
-              },
-              {
-                "id": "8291",
-                "value": "asc"
-              }
-            ],
-            "id": "44478",
-            "key": "variation_2",
-            "featureEnabled": true
-          },
-          {
-            "variables": [
-              {
-                "id": "8289",
-                "value": "6"
-              },
-              {
-                "id": "8290",
-                "value": "category"
-              },
-              {
-                "id": "8291",
-                "value": "desc"
-              }
-            ],
-            "id": "44480",
-            "key": "variation_3",
-            "featureEnabled": true
-          },
-          {
-            "variables": [
-              {
-                "id": "8289",
-                "value": "8"
-              },
-              {
-                "id": "8290",
-                "value": "name"
-              },
-              {
-                "id": "8291",
-                "value": "asc"
-              }
-            ],
-            "id": "44479",
-            "key": "variation_4",
-            "featureEnabled": true
-          }
-        ],
-        "forcedVariations": {},
-        "key": "sorting_algorithm_experiment",
-        "layerId": "9300000053337",
-        "trafficAllocation": [
-          {
-            "entityId": "44477",
-            "endOfRange": 500
-          },
-          {
-            "entityId": "44478",
-            "endOfRange": 1000
-          },
-          {
-            "entityId": "44479",
-            "endOfRange": 1500
-          },
-          {
-            "entityId": "44480",
-            "endOfRange": 2000
-          },
-          {
-            "entityId": "44477",
-            "endOfRange": 4000
-          },
-          {
-            "entityId": "44478",
-            "endOfRange": 6000
-          },
-          {
-            "entityId": "44479",
-            "endOfRange": 8000
-          },
-          {
-            "entityId": "44480",
-            "endOfRange": 10000
-          }
-        ],
-        "id": "9300000061857"
-      },
-      {
-        "status": "Running",
-        "audienceConditions": [],
-        "audienceIds": [],
-        "variations": [
-          {
-            "variables": [
-              {
-                "id": "10748",
-                "value": "Title"
-              }
-            ],
-            "id": "58161",
-            "key": "short_text",
-            "featureEnabled": true
-          },
-          {
-            "variables": [
-              {
-                "id": "10748",
-                "value": "This is the important bit of text called the title."
-              }
-            ],
-            "id": "58160",
-            "key": "long_title",
-            "featureEnabled": true
-          }
-        ],
-        "forcedVariations": {},
-        "key": "header_text_experiment",
-        "layerId": "9300000068249",
-        "trafficAllocation": [
-          {
-            "entityId": "58160",
-            "endOfRange": 5000
-          },
-          {
-            "entityId": "58161",
-            "endOfRange": 10000
-          }
-        ],
-        "id": "9300000090374"
-      }
-    ],
-    "version": "4",
-    "audiences": [
-      {
-        "conditions": "[\"or\", {\"match\": \"exact\", \"name\": \"$opt_dummy_attribute\", \"type\": \"custom_attribute\", \"value\": \"$opt_dummy_value\"}]",
-        "id": "$opt_dummy_audience",
-        "name": "Optimizely-Generated Audience for Backwards Compatibility"
-      }
-    ],
-    "anonymizeIP": true,
-    "attributes": [
-      {
-        "id": "21870951122",
-        "key": "is_employee"
-      }
-    ],
-    "botFiltering": false,
-    "accountId": "21537940595",
-    "events": [
-      {
-        "experimentIds": [
-          "9300000061857",
-          "9300000125242",
-          "9300000090374"
-        ],
-        "id": "21687330054",
-        "key": "subscribe"
-      },
-      {
-        "experimentIds": [],
-        "id": "22305150298",
-        "key": "purchase"
-      }
-    ],
-    "revision": "73"
-  }
+        [
+          "or",
+          [
+            "or",
+            {
+              "match": "substring",
+              "name": "platform",
+              "type": "custom_attribute",
+              "value": "web"
+            }
+          ]
+        ]
+      ]
+    }
+  ],
+  "projectId": "21537940595",
+  "variables": [],
+  "featureFlags": [
+    {
+      "experimentIds": [],
+      "rolloutId": "rollout-19334-21533480907",
+      "variables": [],
+      "id": "19334",
+      "key": "qa_rollout"
+    },
+    {
+      "experimentIds": [
+        "9300000127039"
+      ],
+      "rolloutId": "rollout-29807-21533480907",
+      "variables": [],
+      "id": "29807",
+      "key": "buy_button"
+    },
+    {
+      "experimentIds": [
+        "9300000125242"
+      ],
+      "rolloutId": "rollout-28662-21533480907",
+      "variables": [
+        {
+          "defaultValue": "/index.html",
+          "type": "string",
+          "id": "13752",
+          "key": "path"
+        }
+      ],
+      "id": "28662",
+      "key": "hero_layout"
+    },
+    {
+      "experimentIds": [
+        "9300000061857"
+      ],
+      "rolloutId": "rollout-15415-21533480907",
+      "variables": [
+        {
+          "defaultValue": "asc",
+          "type": "string",
+          "id": "8291",
+          "key": "direction"
+        },
+        {
+          "defaultValue": "price",
+          "type": "string",
+          "id": "8290",
+          "key": "field"
+        },
+        {
+          "defaultValue": "3",
+          "type": "integer",
+          "id": "8289",
+          "key": "number_of_products"
+        }
+      ],
+      "id": "15415",
+      "key": "sorting_algorithm"
+    },
+    {
+      "experimentIds": [
+        "9300000090374"
+      ],
+      "rolloutId": "rollout-19359-21533480907",
+      "variables": [
+        {
+          "defaultValue": "This is the title",
+          "type": "string",
+          "id": "10748",
+          "key": "text"
+        }
+      ],
+      "id": "19359",
+      "key": "header_text"
+    },
+    {
+      "experimentIds": [],
+      "rolloutId": "rollout-19333-21533480907",
+      "variables": [],
+      "id": "19333",
+      "key": "simplified_checkout"
+    }
+  ],
+  "experiments": [
+    {
+      "status": "Running",
+      "audienceConditions": [],
+      "audienceIds": [],
+      "variations": [
+        {
+          "variables": [],
+          "id": "87756",
+          "key": "danger",
+          "featureEnabled": true
+        },
+        {
+          "variables": [],
+          "id": "87758",
+          "key": "warning",
+          "featureEnabled": true
+        },
+        {
+          "variables": [],
+          "id": "87757",
+          "key": "success",
+          "featureEnabled": true
+        },
+        {
+          "variables": [],
+          "id": "87755",
+          "key": "primary",
+          "featureEnabled": true
+        }
+      ],
+      "forcedVariations": {},
+      "key": "buy_button_experiment",
+      "layerId": "9300000093600",
+      "trafficAllocation": [
+        {
+          "entityId": "87755",
+          "endOfRange": 2500
+        },
+        {
+          "entityId": "87756",
+          "endOfRange": 5000
+        },
+        {
+          "entityId": "87757",
+          "endOfRange": 7500
+        },
+        {
+          "entityId": "87758",
+          "endOfRange": 10000
+        }
+      ],
+      "id": "9300000127039"
+    },
+    {
+      "status": "Running",
+      "audienceConditions": [
+        "or",
+        "13858570732"
+      ],
+      "audienceIds": [
+        "13858570732"
+      ],
+      "variations": [
+        {
+          "variables": [
+            {
+              "id": "13752",
+              "value": "/index.html"
+            }
+          ],
+          "id": "84133",
+          "key": "control",
+          "featureEnabled": true
+        },
+        {
+          "variables": [
+            {
+              "id": "13752",
+              "value": "/treatment.html"
+            }
+          ],
+          "id": "84134",
+          "key": "treatment",
+          "featureEnabled": true
+        }
+      ],
+      "forcedVariations": {},
+      "key": "hero_layout_experiment",
+      "layerId": "9300000091821",
+      "trafficAllocation": [
+        {
+          "entityId": "84133",
+          "endOfRange": 5000
+        },
+        {
+          "entityId": "84134",
+          "endOfRange": 10000
+        }
+      ],
+      "id": "9300000125242"
+    },
+    {
+      "status": "Running",
+      "audienceConditions": [],
+      "audienceIds": [],
+      "variations": [
+        {
+          "variables": [],
+          "id": "44475",
+          "key": "off",
+          "featureEnabled": false
+        },
+        {
+          "variables": [
+            {
+              "id": "8289",
+              "value": "4"
+            },
+            {
+              "id": "8291",
+              "value": "desc"
+            },
+            {
+              "id": "8290",
+              "value": "price"
+            }
+          ],
+          "id": "44477",
+          "key": "variation_1",
+          "featureEnabled": true
+        },
+        {
+          "variables": [
+            {
+              "id": "8289",
+              "value": "5"
+            },
+            {
+              "id": "8290",
+              "value": "category"
+            },
+            {
+              "id": "8291",
+              "value": "asc"
+            }
+          ],
+          "id": "44478",
+          "key": "variation_2",
+          "featureEnabled": true
+        },
+        {
+          "variables": [
+            {
+              "id": "8289",
+              "value": "6"
+            },
+            {
+              "id": "8290",
+              "value": "category"
+            },
+            {
+              "id": "8291",
+              "value": "desc"
+            }
+          ],
+          "id": "44480",
+          "key": "variation_3",
+          "featureEnabled": true
+        },
+        {
+          "variables": [
+            {
+              "id": "8289",
+              "value": "8"
+            },
+            {
+              "id": "8290",
+              "value": "name"
+            },
+            {
+              "id": "8291",
+              "value": "asc"
+            }
+          ],
+          "id": "44479",
+          "key": "variation_4",
+          "featureEnabled": true
+        }
+      ],
+      "forcedVariations": {},
+      "key": "sorting_algorithm_experiment",
+      "layerId": "9300000053337",
+      "trafficAllocation": [
+        {
+          "entityId": "44477",
+          "endOfRange": 500
+        },
+        {
+          "entityId": "44478",
+          "endOfRange": 1000
+        },
+        {
+          "entityId": "44479",
+          "endOfRange": 1500
+        },
+        {
+          "entityId": "44480",
+          "endOfRange": 2000
+        },
+        {
+          "entityId": "44477",
+          "endOfRange": 4000
+        },
+        {
+          "entityId": "44478",
+          "endOfRange": 6000
+        },
+        {
+          "entityId": "44479",
+          "endOfRange": 8000
+        },
+        {
+          "entityId": "44480",
+          "endOfRange": 10000
+        }
+      ],
+      "id": "9300000061857"
+    },
+    {
+      "status": "Running",
+      "audienceConditions": [],
+      "audienceIds": [],
+      "variations": [
+        {
+          "variables": [
+            {
+              "id": "10748",
+              "value": "Title"
+            }
+          ],
+          "id": "58161",
+          "key": "short_text",
+          "featureEnabled": true
+        },
+        {
+          "variables": [
+            {
+              "id": "10748",
+              "value": "This is the important bit of text called the title."
+            }
+          ],
+          "id": "58160",
+          "key": "long_title",
+          "featureEnabled": true
+        }
+      ],
+      "forcedVariations": {},
+      "key": "header_text_experiment",
+      "layerId": "9300000068249",
+      "trafficAllocation": [
+        {
+          "entityId": "58160",
+          "endOfRange": 5000
+        },
+        {
+          "entityId": "58161",
+          "endOfRange": 10000
+        }
+      ],
+      "id": "9300000090374"
+    }
+  ],
+  "version": "4",
+  "audiences": [
+    {
+      "conditions": "[\"or\", {\"match\": \"exact\", \"name\": \"$opt_dummy_attribute\", \"type\": \"custom_attribute\", \"value\": \"$opt_dummy_value\"}]",
+      "id": "$opt_dummy_audience",
+      "name": "Optimizely-Generated Audience for Backwards Compatibility"
+    }
+  ],
+  "anonymizeIP": true,
+  "attributes": [
+    {
+      "id": "21870951122",
+      "key": "is_employee"
+    }
+  ],
+  "botFiltering": false,
+  "accountId": "21537940595",
+  "events": [
+    {
+      "experimentIds": [
+        "9300000061857",
+        "9300000125242",
+        "9300000090374"
+      ],
+      "id": "21687330054",
+      "key": "subscribe"
+    },
+    {
+      "experimentIds": [],
+      "id": "22305150298",
+      "key": "purchase"
+    }
+  ],
+  "revision": "73"
+}

--- a/optimizely/Cargo.toml
+++ b/optimizely/Cargo.toml
@@ -9,6 +9,8 @@ thiserror = "1.0"
 error-stack = "0.3.1"
 murmur3 = "0.5.2"
 log = "0.4.17"
+num-ord = "0.1.0"
+serde-value = "0.7.0"
 
 [dependencies.serde]
 version = "1.0.188"

--- a/optimizely/src/client.rs
+++ b/optimizely/src/client.rs
@@ -8,7 +8,7 @@ use crate::event_api::EventDispatcher;
 // Relative imports of sub modules
 pub use error::ClientError;
 pub use initialization::UninitializedClient;
-pub use user::{UserAttributes, UserContext};
+pub use user::{AttributeValue, UserAttributes, UserContext};
 
 mod error;
 mod initialization;

--- a/optimizely/src/datafile.rs
+++ b/optimizely/src/datafile.rs
@@ -5,6 +5,11 @@ use std::collections::HashMap;
 use error_stack::{IntoReport, Result, ResultExt};
 
 // Relative imports of sub modules
+use audience::Audience;
+pub use audience_condition::{
+    AudienceCondition, CustomAttributeCondition, ExactCondition, ExistsCondition, NumericCondition, SubstringCondition,
+};
+pub use boolean_condition::BooleanCondition;
 use environment::Environment;
 pub use error::DatafileError;
 use event::Event;
@@ -14,6 +19,9 @@ use rollout::Rollout;
 use traffic_allocation::TrafficAllocation;
 pub(crate) use variation::Variation;
 
+mod audience;
+mod audience_condition;
+mod boolean_condition;
 mod environment;
 mod error;
 mod event;
@@ -80,5 +88,9 @@ impl Datafile {
     /// Get the event with the given key
     pub fn event(&self, event_key: &str) -> Option<&Event> {
         self.0.events().get(event_key)
+    }
+
+    pub fn audience(&self, audience_id: &str) -> Option<&Audience> {
+        self.0.audiences().get(audience_id)
     }
 }

--- a/optimizely/src/datafile/audience.rs
+++ b/optimizely/src/datafile/audience.rs
@@ -1,0 +1,45 @@
+// External imports
+use serde::{Deserialize, Deserializer};
+use std::collections::HashMap;
+
+// Imports from super
+use super::{AudienceCondition, BooleanCondition};
+
+#[derive(Deserialize, Debug)]
+pub struct Audience {
+    conditions: BooleanCondition<AudienceCondition>,
+    id: String,
+    name: String,
+}
+
+impl Audience {
+    // Method to deserialize an array of Audiences into a Hashmap of Audiences
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<HashMap<String, Audience>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let mut map = HashMap::new();
+        for audience in Vec::<Audience>::deserialize(deserializer)? {
+            map.insert(audience.id.clone(), audience);
+        }
+        Ok(map)
+    }
+
+    /// Getter for `id` field
+    #[allow(dead_code)]
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Getter for `name` field
+    #[allow(dead_code)]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Getter for `conditions` field
+    #[allow(dead_code)]
+    pub fn conditions(&self) -> &BooleanCondition<AudienceCondition> {
+        &self.conditions
+    }
+}

--- a/optimizely/src/datafile/audience_condition.rs
+++ b/optimizely/src/datafile/audience_condition.rs
@@ -1,0 +1,194 @@
+use std::cmp::Ordering;
+
+// External imports
+use num_ord::NumOrd;
+use serde::Deserialize;
+use serde_json::value::{Number, Value};
+
+// Imports from crate
+use crate::client::UserAttributes;
+
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(tag = "type")]
+pub enum AudienceCondition {
+    #[serde(rename = "custom_attribute")]
+    CustomAttribute(CustomAttributeCondition),
+    // #[serde(rename = "third_party_dimension")]
+    // ThirdPartyDimension(ThirdPartyDimensionCondition),
+}
+
+impl AudienceCondition {
+    // Method to evaluate a condition
+    pub fn evaluate(&self, user_attributes: &UserAttributes) -> bool {
+        match self {
+            AudienceCondition::CustomAttribute(condition) => condition.evaluate(user_attributes),
+            // AudienceCondition::ThirdPartyDimension(condition) => condition.evaluate(user_attributes),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(tag = "match")]
+pub enum CustomAttributeCondition {
+    #[serde(rename = "exact")]
+    Exact(ExactCondition),
+    #[serde(rename = "exists")]
+    Exists(ExistsCondition),
+    #[serde(rename = "gt")]
+    GreaterThan(NumericCondition),
+    #[serde(rename = "ge")]
+    GreaterThanOrEqualTo(NumericCondition),
+    #[serde(rename = "lt")]
+    LessThan(NumericCondition),
+    #[serde(rename = "le")]
+    LessThanOrEqualTo(NumericCondition),
+    #[serde(rename = "substring")]
+    Substring(SubstringCondition),
+    // #[serde(rename = "semver_eq")]
+    // SemverEqualTo(SemverCondition),
+    // #[serde(rename = "semver_gt")]
+    // SemverGreaterThan(SemverCondition),
+    // #[serde(rename = "semver_ge")]
+    // SemverGreaterThanOrEqualTo(SemverCondition),
+    // #[serde(rename = "semver_lt")]
+    // SemverLessThan(SemverCondition),
+    // #[serde(rename = "semver_le")]
+    // SemverLessThanOrEqualTo(SemverCondition),
+    #[serde(other)]
+    Unknown,
+}
+
+impl CustomAttributeCondition {
+    // Method to evaluate a condition
+    pub fn evaluate(&self, user_attributes: &UserAttributes) -> bool {
+        match self {
+            CustomAttributeCondition::Exact(condition) => condition.evaluate(user_attributes),
+            CustomAttributeCondition::Exists(condition) => condition.evaluate(user_attributes),
+            CustomAttributeCondition::GreaterThan(condition) => condition
+                .compare(user_attributes)
+                .is_some_and(|x| x.is_gt()),
+            CustomAttributeCondition::GreaterThanOrEqualTo(condition) => condition
+                .compare(user_attributes)
+                .is_some_and(|x| x.is_ge()),
+            CustomAttributeCondition::LessThan(condition) => condition
+                .compare(user_attributes)
+                .is_some_and(|x| x.is_lt()),
+            CustomAttributeCondition::LessThanOrEqualTo(condition) => condition
+                .compare(user_attributes)
+                .is_some_and(|x| x.is_le()),
+            CustomAttributeCondition::Substring(condition) => condition.evaluate(user_attributes),
+            CustomAttributeCondition::Unknown => {
+                log::warn!("unrecognized match type in audience condition");
+                false
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct ExactCondition {
+    pub name: String,
+    pub value: Value,
+}
+
+impl ExactCondition {
+    // Method to evaluate a condition
+    pub fn evaluate(&self, user_attributes: &UserAttributes) -> bool {
+        let optional_user_value = user_attributes.get(&self.name);
+        if optional_user_value.is_none() {
+            return false;
+        }
+        let user_value = optional_user_value.unwrap();
+        if user_value.is_null() {
+            return false;
+        }
+        match &self.value {
+            Value::Bool(condition_value) => {
+                return user_value.as_bool().is_some_and(|x| x == condition_value);
+            }
+            Value::Number(condition_value) => {
+                return user_value.as_number().is_some_and(|x| x == condition_value);
+            }
+            Value::String(condition_value) => {
+                return user_value.as_str().is_some_and(|x| x == condition_value);
+            }
+            _ => false,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct ExistsCondition {
+    name: String,
+}
+
+impl ExistsCondition {
+    // Method to evaluate a condition
+    pub fn evaluate(&self, user_attributes: &UserAttributes) -> bool {
+        user_attributes
+            .get(&self.name)
+            .is_some_and(|attribute| !attribute.is_null())
+    }
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct NumericCondition {
+    name: String,
+    value: Number,
+}
+
+impl NumericCondition {
+    // Returns Some<Equal> if user_attributes.get(self.name) == self.value
+    // Returns Some<Greater> if user_attributes.get(self.name) > self.value
+    // Returns Some<Less> if user_attributes.get(self.name) < self.value
+    // Returns None if user_attributes.get(self.name) is absent, not a number, or "incomparable"
+    // to self.value. I'm not sure what incomparable means, but I think `NaN` is probably
+    // incomparable to everything
+    pub fn compare(&self, user_attributes: &UserAttributes) -> Option<Ordering> {
+        if let Some(crate::client::AttributeValue::Number(attribute_value)) = user_attributes.get(&self.name) {
+            if let Some(attribute_u64) = attribute_value.as_u64() {
+                if let Some(condition_u64) = self.value.as_u64() {
+                    return Some(attribute_u64.cmp(&condition_u64));
+                } else if let Some(condition_i64) = self.value.as_i64() {
+                    return NumOrd(attribute_u64).partial_cmp(&NumOrd(condition_i64));
+                } else if let Some(condition_f64) = self.value.as_f64() {
+                    return NumOrd(attribute_u64).partial_cmp(&NumOrd(condition_f64));
+                }
+            } else if let Some(attribute_i64) = attribute_value.as_i64() {
+                if let Some(condition_u64) = self.value.as_u64() {
+                    return NumOrd(attribute_i64).partial_cmp(&NumOrd(condition_u64));
+                } else if let Some(condition_i64) = self.value.as_i64() {
+                    return Some(attribute_i64.cmp(&condition_i64));
+                } else if let Some(condition_f64) = self.value.as_f64() {
+                    return NumOrd(attribute_i64).partial_cmp(&NumOrd(condition_f64));
+                }
+            } else if let Some(attribute_f64) = attribute_value.as_f64() {
+                if let Some(condition_u64) = self.value.as_u64() {
+                    return NumOrd(attribute_f64).partial_cmp(&NumOrd(condition_u64));
+                } else if let Some(condition_i64) = self.value.as_i64() {
+                    return NumOrd(attribute_f64).partial_cmp(&NumOrd(condition_i64));
+                } else if let Some(condition_f64) = self.value.as_f64() {
+                    return NumOrd(attribute_f64).partial_cmp(&NumOrd(condition_f64));
+                }
+            }
+        }
+        None
+    }
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct SubstringCondition {
+    pub name: String,
+    pub value: String,
+}
+
+impl SubstringCondition {
+    // Method to evaluate a condition
+    pub fn evaluate(&self, user_attributes: &UserAttributes) -> bool {
+        return user_attributes.get(&self.name).is_some_and(|attribute| {
+            attribute
+                .as_str()
+                .is_some_and(|str_attribute| str_attribute.contains(&self.value))
+        });
+    }
+}

--- a/optimizely/src/datafile/boolean_condition.rs
+++ b/optimizely/src/datafile/boolean_condition.rs
@@ -1,0 +1,198 @@
+use serde::de::value::{
+    BoolDeserializer, BytesDeserializer, F64Deserializer, I128Deserializer, I64Deserializer, MapAccessDeserializer,
+    StrDeserializer, U128Deserializer, U64Deserializer,
+};
+// External imports
+use serde::{de::Visitor, Deserialize, Deserializer};
+use serde_value::{Value, ValueDeserializer};
+use std::cmp;
+use std::marker::PhantomData;
+
+#[derive(Debug, PartialEq)]
+pub enum BooleanCondition<T> {
+    And(Vec<Box<BooleanCondition<T>>>),
+    Or(Vec<Box<BooleanCondition<T>>>),
+    Not(Option<Box<BooleanCondition<T>>>),
+    Single(T),
+}
+
+impl<'de, T> Deserialize<'de> for BooleanCondition<T>
+where
+    T: Deserialize<'de>,
+{
+    // Method to deserialize an array into a BooleanCondition
+    fn deserialize<D>(deserializer: D) -> Result<BooleanCondition<T>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct BooleanConditionVisitor<T> {
+            // https://serde.rs/deserialize-map.html
+            marker: PhantomData<fn() -> BooleanCondition<T>>,
+        }
+
+        impl<T> BooleanConditionVisitor<T> {
+            fn new() -> Self {
+                BooleanConditionVisitor { marker: PhantomData }
+            }
+        }
+
+        impl<'de, T> Visitor<'de> for BooleanConditionVisitor<T>
+        where
+            T: Deserialize<'de>,
+        {
+            type Value = BooleanCondition<T>;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                // Examples: ["or", 1, 2, 3]; ["or", ["and", { "name": "thing1" }, { "name": "thing2" }, { "name": "thing3" }]]
+                formatter.write_str(
+                    "an array whose first element is 'and', 'or', or 'not' and subsequent elements are T, or another array",
+                )
+            }
+
+            // Most of these visit_... functions just say, "deserialize it as a `T`, then wrap it in a BooleanCondition::Single"
+            // visit_seq is the only exeception
+            fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(BooleanCondition::Single(T::deserialize(BoolDeserializer::new(v))?))
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(BooleanCondition::Single(T::deserialize(BytesDeserializer::new(v))?))
+            }
+
+            fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(BooleanCondition::Single(T::deserialize(F64Deserializer::new(v))?))
+            }
+
+            fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(BooleanCondition::Single(T::deserialize(I128Deserializer::new(v))?))
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(BooleanCondition::Single(T::deserialize(I64Deserializer::new(v))?))
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(BooleanCondition::Single(T::deserialize(StrDeserializer::new(v))?))
+            }
+
+            fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(BooleanCondition::Single(T::deserialize(U128Deserializer::new(v))?))
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(BooleanCondition::Single(T::deserialize(U64Deserializer::new(v))?))
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                Ok(BooleanCondition::Single(T::deserialize(MapAccessDeserializer::new(map))?))
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut condition: BooleanCondition<T>;
+                let size_hint = seq.size_hint().unwrap_or(0);
+                if let Some(first_element) = seq.next_element::<Value>()? {
+                    match first_element {
+                        Value::String(ref first_str) => {
+                            if first_str == "and" {
+                                condition = BooleanCondition::And(Vec::with_capacity(cmp::max(1, size_hint) - 1));
+                            } else if first_str == "or" {
+                                condition = BooleanCondition::Or(Vec::with_capacity(cmp::max(1, size_hint) - 1));
+                            } else if first_str == "not" {
+                                return Ok(BooleanCondition::Not(seq.next_element()?));
+                            } else {
+                                // https://stackoverflow.com/questions/74461366/how-do-i-deserialize-the-last-element-of-a-serde-sequence-differently-from-the-r
+                                let mut vec = Vec::with_capacity(size_hint);
+                                vec.push(Box::new(BooleanCondition::<T>::deserialize(ValueDeserializer::new(
+                                    first_element,
+                                ))?));
+                                condition = BooleanCondition::Or(vec)
+                            }
+                        }
+                        _ => {
+                            let mut vec = Vec::with_capacity(size_hint);
+                            vec.push(Box::new(BooleanCondition::<T>::deserialize(ValueDeserializer::new(
+                                first_element,
+                            ))?));
+                            condition = BooleanCondition::Or(vec)
+                        }
+                    }
+                    while let Some(next_element) = seq.next_element::<BooleanCondition<T>>()? {
+                        match condition {
+                            BooleanCondition::And(ref mut vec) => vec.push(Box::new(next_element)),
+                            BooleanCondition::Or(ref mut vec) => vec.push(Box::new(next_element)),
+                            _ => (),
+                        }
+                    }
+                    Ok(condition)
+                } else {
+                    Ok(BooleanCondition::And(Vec::new()))
+                }
+            }
+        }
+
+        deserializer.deserialize_any(BooleanConditionVisitor::new())
+    }
+}
+
+impl<T> BooleanCondition<T> {
+    // Method to evaluate a condition
+    pub fn evaluate<E>(&self, evaluator: &E) -> bool
+    where
+        E: Fn(&T) -> bool,
+    {
+        match self {
+            BooleanCondition::And(conditions) => conditions
+                .iter()
+                .all(|condition| condition.evaluate(evaluator)),
+            BooleanCondition::Or(conditions) => conditions
+                .iter()
+                .any(|condition| condition.evaluate(evaluator)),
+            BooleanCondition::Not(option) => {
+                if let Some(condition) = option {
+                    return !condition.evaluate(evaluator);
+                }
+                return false;
+            }
+            BooleanCondition::Single(condition) => evaluator(&condition),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            BooleanCondition::And(conditions) => conditions.is_empty(),
+            BooleanCondition::Or(conditions) => conditions.is_empty(),
+            BooleanCondition::Not(conditions) => conditions.is_none(),
+            _ => false,
+        }
+    }
+}

--- a/optimizely/src/datafile/environment.rs
+++ b/optimizely/src/datafile/environment.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
 
 // Imports from super
-use super::{Event, Experiment, FeatureFlag, Rollout};
+use super::{Audience, Event, Experiment, FeatureFlag, Rollout};
 
 #[derive(Deserialize, Debug)]
 pub struct Environment {
@@ -19,6 +19,8 @@ pub struct Environment {
     bot_filtering: bool,
     #[serde(rename = "anonymizeIP")]
     anonymize_ip: bool,
+    #[serde(rename = "typedAudiences", deserialize_with = "Audience::deserialize")]
+    audiences: HashMap<String, Audience>,
     #[serde(rename = "events", deserialize_with = "Event::deserialize")]
     events: HashMap<String, Event>,
     #[serde(deserialize_with = "Experiment::deserialize")]
@@ -67,6 +69,10 @@ impl Environment {
     #[allow(dead_code)]
     pub fn anonymize_ip(&self) -> bool {
         self.anonymize_ip
+    }
+
+    pub fn audiences(&self) -> &HashMap<String, Audience> {
+        &self.audiences
     }
 
     pub fn feature_flags(&self) -> &HashMap<String, FeatureFlag> {

--- a/optimizely/tests/client_initialization.rs
+++ b/optimizely/tests/client_initialization.rs
@@ -1,8 +1,16 @@
 // Imports from Optimizely crate
-use optimizely::{client::ClientError, datafile::DatafileError, Client};
+use optimizely::{
+    client::ClientError,
+    datafile::{
+        AudienceCondition, BooleanCondition, CustomAttributeCondition, DatafileError, ExactCondition,
+        SubstringCondition,
+    },
+    Client,
+};
 
 // Relative imports of sub modules
 use common::{ACCOUNT_ID, FILE_PATH, REVISION};
+use serde_json::Value;
 mod common;
 
 #[test]
@@ -111,4 +119,31 @@ fn with_fixed_datafile() {
 
     // Check revision property on client
     assert_eq!(client.datafile().revision(), REVISION);
+
+    assert_eq!(client.datafile().audience("13858570732").unwrap().name(), "[Web] Desktop Only");
+    assert_eq!(
+        *client
+            .datafile()
+            .audience("13858570732")
+            .unwrap()
+            .conditions(),
+        BooleanCondition::And(vec![
+            Box::new(BooleanCondition::Or(vec![Box::new(BooleanCondition::Or(vec![Box::new(
+                BooleanCondition::Single(AudienceCondition::CustomAttribute(CustomAttributeCondition::Exact(
+                    ExactCondition {
+                        name: "isMobile".into(),
+                        value: Value::Bool(false),
+                    }
+                )))
+            )]))])),
+            Box::new(BooleanCondition::Or(vec![Box::new(BooleanCondition::Or(vec![Box::new(
+                BooleanCondition::Single(AudienceCondition::CustomAttribute(CustomAttributeCondition::Substring(
+                    SubstringCondition {
+                        name: "platform".into(),
+                        value: "web".into(),
+                    }
+                )))
+            )]))])),
+        ])
+    );
 }

--- a/optimizely/tests/user_context.rs
+++ b/optimizely/tests/user_context.rs
@@ -1,8 +1,10 @@
 // Imports from Optimizely crate
+use optimizely::client::AttributeValue;
 use optimizely::user_attributes;
 
 // Relative imports of sub modules
 use common::setup;
+use serde_json::{json, Number};
 mod common;
 
 #[test]
@@ -13,12 +15,40 @@ fn user_context_set_attribute() {
     let mut user_context = ctx.client.create_user_context("user123");
 
     // Override attributes on existing user context
-    user_context.set_attribute("is_employee", "true");
+    user_context.set_attribute("is_employee", true);
     user_context.set_attribute("app_version", "1.3.2");
+    user_context.set_attribute("count", 47);
+    user_context.set_attribute("nothing", AttributeValue::Null);
 
     // Attributes should be equal to expected
-    assert_eq!(user_context.attributes().get("is_employee").unwrap(), "true");
-    assert_eq!(user_context.attributes().get("app_version").unwrap(), "1.3.2");
+    assert!(user_context
+        .attributes()
+        .get("is_employee")
+        .unwrap()
+        .as_bool()
+        .unwrap());
+    assert_eq!(
+        user_context
+            .attributes()
+            .get("app_version")
+            .unwrap()
+            .as_str()
+            .unwrap(),
+        "1.3.2"
+    );
+    assert_eq!(
+        user_context
+            .attributes()
+            .get("count")
+            .unwrap()
+            .as_number()
+            .unwrap(),
+        &Number::from(47)
+    );
+    assert_eq!(
+        json!(user_context.attributes()).to_string(),
+        "{\"app_version\":\"1.3.2\",\"count\":47,\"is_employee\":true,\"nothing\":null}"
+    );
 }
 
 #[test]
@@ -29,14 +59,27 @@ fn user_context_with_attributes() {
     let user_context = ctx.client.create_user_context_with_attributes(
         "user123",
         user_attributes! {
-            "is_employee" => "true",
+            "is_employee" => true,
             "app_version" => "1.3.2",
         },
     );
 
     // Attributes should be equal to expected
-    assert_eq!(user_context.attributes().get("is_employee").unwrap(), "true");
-    assert_eq!(user_context.attributes().get("app_version").unwrap(), "1.3.2");
+    assert!(user_context
+        .attributes()
+        .get("is_employee")
+        .unwrap()
+        .as_bool()
+        .unwrap());
+    assert_eq!(
+        user_context
+            .attributes()
+            .get("app_version")
+            .unwrap()
+            .as_str()
+            .unwrap(),
+        "1.3.2"
+    );
 }
 
 #[test]


### PR DESCRIPTION
[ZUM-62846](https://zumper.atlassian.net/browse/ZUM-62846)

Goes with https://github.com/zumper/web-zumper/pull/6563 and https://github.com/zumper/fastly-edge-compute/pull/189

The goal is to have the `isMobile` attribute included in the Optimizely `user` objects, so that it will:

1. Be considered when deciding whether to include the user in an experiment (by evaluating the audience conditions associated with the experiment) and
2. Be sent as part of Optimizely events (events like, "the user sent a message")

This PR has 3 commits:

# Commit 1: fix: allow non-string values in `UserAttributes`
The first commit adjusts the `UserAttributes` type (which is a `HashMap`), so that it supports non-string values (specifically null, number, string, and boolean). This is important because (from https://docs.developers.optimizely.com/full-stack-experimentation/docs/pass-in-audience-attributes-javascript):
> Important
>
> During audience evaluation, note that if you do not pass a valid attribute value for a given audience condition—for example, if you pass a string when the audience condition requires a Boolean, or if you simply forget to pass a value—then that condition will be skipped. The [SDK logs](https://docs.developers.optimizely.com/full-stack-experimentation/docs/customize-logger-javascript) will include warnings when this occurs.

Specifically, our `isMobile` attribute is a boolean: 
![image](https://github.com/zumper/optimizely-rust-sdk/assets/696145/c5e5f325-233d-4149-a06c-5aedb0e913f2)

# Commit 2: feat: evaluating audience conditions
The second commit adds support for parsing and evaluating audience conditions. I used the Optimizely JS SDK as a guide

In [the Readme of the repo we forked, note that "Evaluating audience conditions" isn't a feature they already supported](https://github.com/zumper/optimizely-rust-sdk)

## Part 1: Parsing audience conditions

This library already including support for parsing the Optimizely datafile, but they ignored (didn't parse) the parts of the datafile they weren't using, which included audiences. I created data structures and deserializers for audiences. The most complicated part were the "conditions". These are represented in the datafile using a recursive array structure, like:

```js
[
  // the first element in the array can be "and", "or", or "not", and indicates how the
  // remaining elements in the array should be combined.
  // If the first item is not one of those 3 strings, we (the Optimizely JS SDK and I) act
  // as though there were an "or".
  // For "not", we negate the second item in the array, and ignore any subsequent items.
  "and",
  [
    "or",
    { "type": "custom_attribute", "match": "exact", "name": "isMobile", "value": true },
    { "type": "custom_attribute", "match": "exact", "name": "platform", "value": "ios" },
    { "type": "custom_attribute", "match": "exact", "name": "platform", "value": "android" }
  ],
  { "type": "custom_attribute", "match": "gt", "name": "leads_sent", "value": 0 }
]
```

This structure is also used to specify which audiences apply to an experiment (e.g. `["or", "1234", "5678"]` -- the user must be in the audience whose id is `1234` or `5678`)

I named the recursive structure `BooleanCondition` and the objects inside it `AudienceCondition`. Below is an excerpt of our datafile with the types added:
![image](https://github.com/zumper/optimizely-rust-sdk/assets/696145/73398dd4-af24-4f34-806a-eae05722f840)

## Part 2: Evaluating audience conditions

`BooleanCondition` and `AudienceCondition` have `evaluate` methods that are used to compare a user's attributes to the conditions in the datafile

# Commit 3: build: add ci

The last commit adds `.circleci/config.yml`, so the unit tests will run in CI

[ZUM-62846]: https://zumper.atlassian.net/browse/ZUM-62846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ